### PR TITLE
add transparency

### DIFF
--- a/castero/display.py
+++ b/castero/display.py
@@ -44,7 +44,8 @@ class Display:
         'magenta': curses.COLOR_MAGENTA,
         'red': curses.COLOR_RED,
         'white': curses.COLOR_WHITE,
-        'yellow': curses.COLOR_YELLOW
+        'yellow': curses.COLOR_YELLOW,
+        'transparent': -1
     }
     KEY_MAPPING = {chr(i): i for i in range(256)}
     KEY_MAPPING.update(
@@ -107,6 +108,9 @@ class Display:
         assert self._config["color_background"] in self.AVAILABLE_COLORS
         assert self._config["color_foreground_alt"] in self.AVAILABLE_COLORS
         assert self._config["color_background_alt"] in self.AVAILABLE_COLORS
+
+        if (self.AVAILABLE_COLORS[self._config["color_background"]] == -1 or self.AVAILABLE_COLORS[self._config["color_background_alt"]] == -1):
+            curses.use_default_colors()
 
         curses.init_pair(
             1,

--- a/castero/templates/castero.conf
+++ b/castero/templates/castero.conf
@@ -30,7 +30,8 @@ custom_download_dir =
 
 [colors]
 # Available colors for all fields are:
-# black, blue, cyan, green, magenta, red, white, yellow
+# black, blue, cyan, green, magenta, red, white, yellow, transparent (background)
+# NOTE:  Background transparency only works with compatible terminals
 
 # The foreground (text) color of the main interface.
 # default: yellow


### PR DESCRIPTION
I made small changes to `castero/display.py` to enable users to set background transparency in their `castero.conf` files.