### PR TITLE
add background transparency

### DIFF
--- a/castero/display.py
+++ b/castero/display.py
@@ -44,7 +44,8 @@ class Display:
         'magenta': curses.COLOR_MAGENTA,
         'red': curses.COLOR_RED,
         'white': curses.COLOR_WHITE,
-        'yellow': curses.COLOR_YELLOW
+        'yellow': curses.COLOR_YELLOW,
+        'transparent': -1
     }
     KEY_MAPPING = {chr(i): i for i in range(256)}
     KEY_MAPPING.update(
@@ -107,6 +108,9 @@ class Display:
         assert self._config["color_background"] in self.AVAILABLE_COLORS
         assert self._config["color_foreground_alt"] in self.AVAILABLE_COLORS
         assert self._config["color_background_alt"] in self.AVAILABLE_COLORS
+
+        if (self.AVAILABLE_COLORS[self._config["color_background"]] == -1 or self.AVAILABLE_COLORS[self._config["color_background_alt"]] == -1):
+            curses.use_default_colors()
 
         curses.init_pair(
             1,

--- a/castero/templates/castero.conf
+++ b/castero/templates/castero.conf
@@ -30,7 +30,8 @@ custom_download_dir =
 
 [colors]
 # Available colors for all fields are:
-# black, blue, cyan, green, magenta, red, white, yellow
+# black, blue, cyan, green, magenta, red, white, yellow, transparent (background)
+# NOTE:  Background transparency only works on compatible terminals with compositing
 
 # The foreground (text) color of the main interface.
 # default: yellow


### PR DESCRIPTION
I made some small additions in `castero/display.py` to allow users to set background transparency in `castero.conf`, so long as they have a terminal with compositing.  `castero/templates/castero.conf` reflects this change.

Transparency in action:
https://imageshack.com/a/img924/3040/fwEIdB.png