### PR TITLE
Don't crash if there are download errors

### DIFF
--- a/castero/display.py
+++ b/castero/display.py
@@ -592,7 +592,11 @@ class Display:
         self._queue.update()
 
         # check the status of any downloads
-        self._download_queue.update()
+        try:
+            self._download_queue.update()
+        except Exception as e:
+            self.change_status("Error: %s" % (str(e)))
+            return
 
         # update the status timer
         # If the user is not doing anything, the status message will take


### PR DESCRIPTION
Updates the status bar with any unhandled exceptions on downloading (like the inability to write to the disk or create the download directory), instead of crashing.  I am not entirely sure how to create a test for this under the current framework.