### PR TITLE
add wrapping CJK text support when display Metadata

### DIFF
--- a/castero/perspective.py
+++ b/castero/perspective.py
@@ -1,6 +1,7 @@
 import curses
-import textwrap
 from abc import ABC, abstractmethod
+
+import cjkwrap
 
 from castero.menu import Menu
 
@@ -223,7 +224,7 @@ class Perspective(ABC):
         """
         max_lines = int(0.7 * window.getmaxyx()[0])
         max_line_width = window.getmaxyx()[1] - 1
-        lines = textwrap.wrap(string, max_line_width)
+        lines = cjkwrap.wrap(string, max_line_width)
 
         # truncate to at most 70% of the total lines on the screen
         lines = lines[:max_lines]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-vlc==3.0.4106
 requests==2.20.0
 pytest==3.9.3
+CJKwrap==2.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ import castero
 
 install_requires = [
     'requests',
-    'python-vlc'
+    'python-vlc',
+    'cjkwrap'
 ]
 
 tests_require = [


### PR DESCRIPTION
I have some podcast from China，but the python lib textwrap support for CJK text has a bug。
So i change textwrap to cjkwrap， and now the metadata display correctly。