### PR TITLE
Separate seek distances for forward and backward

### DIFF
--- a/castero/queue.py
+++ b/castero/queue.py
@@ -79,7 +79,8 @@ class Queue:
         assert direction == 1 or direction == -1
 
         if self.first is not None:
-            self.first.seek(direction, int(Config["seek_distance"]))
+            distance = int(Config["seek_distance_forward" if direction == 1 else "seek_distance_backward"])
+            self.first.seek(direction, distance)
 
     def remove(self, player) -> int:
         """Remove a player from the queue, if it is currently in it.

--- a/castero/templates/castero.conf
+++ b/castero/templates/castero.conf
@@ -84,9 +84,13 @@ color_background_alt = black
 
 
 [playback]
-# The distance to move forward/backward when pressing seek keys, in seconds.
+# The distance to move forward when pressing seek keys, in seconds.
+# default: 30
+seek_distance_forward = 30
+
+# The distance to move backward when pressing seek keys, in seconds.
 # default: 10
-seek_distance = 10
+seek_distance_backward = 10
 
 
 [keys]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,7 +40,8 @@ def test_config_excessive_migrate():
     copyfile(my_dir + "/datafiles/excessive_error.conf", config._Config.PATH)
     myconfig = config._Config()
     assert "this_should_not_be_here" not in myconfig
-    assert "seek_distance" in myconfig
+    assert "seek_distance_forward" in myconfig
+    assert "seek_distance_backward" in myconfig
 
 
 def test_config_length():
@@ -56,8 +57,8 @@ def test_config_iter():
 
 def test_config_get_item():
     myconfig = config._Config()
-    seek_distance = myconfig["seek_distance"]
-    assert seek_distance is not None
+    seek_distance_forward = myconfig["seek_distance_forward"]
+    assert seek_distance_forward is not None
 
 
 def test_config_try_set_item():
@@ -68,8 +69,8 @@ def test_config_try_set_item():
 
 def test_config_del_item():
     myconfig = config._Config()
-    del myconfig["seek_distance"]
-    assert "seek_distance" not in myconfig
+    del myconfig["seek_distance_forward"]
+    assert "seek_distance_forward" not in myconfig
 
 
 def test_migrate_stability():

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -140,10 +140,18 @@ def test_queue_toggle():
     player1.pause.assert_called_once()
 
 
-def test_queue_seek():
+def test_queue_seek_forward():
     myqueue = Queue()
     player1 = mock.MagicMock(spec=Player)
 
     myqueue.add(player1)
     myqueue.seek(1)
-    player1.seek.assert_called_with(1, int(Config["seek_distance"]))
+    player1.seek.assert_called_with(1, int(Config["seek_distance_forward"]))
+
+def test_queue_seek_backward():
+    myqueue = Queue()
+    player1 = mock.MagicMock(spec=Player)
+
+    myqueue.add(player1)
+    myqueue.seek(-1)
+    player1.seek.assert_called_with(-1, int(Config["seek_distance_backward"]))


### PR DESCRIPTION
I'd like to be able to have different seek speeds for forward and backward, this should enable that. I have set the default to 30 forward and 10 backward.