### PR TITLE
fix menu dimensions after resize

### DIFF
--- a/castero/display.py
+++ b/castero/display.py
@@ -598,6 +598,7 @@ class Display:
         if current_y != self._parent_y or current_x != self._parent_x:
             self._parent_y, self._parent_x = current_y, current_x
             self._create_windows()
+            self.create_menus()
             self.menus_valid = False
             self.refresh()
 


### PR DESCRIPTION
fixing a gap in the menu and a crash:
```
Traceback (most recent call last):
  File "/usr/bin/castero", line 11, in <module>
    load_entry_point('castero==0.5.5', 'console_scripts', 'castero')()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2843, in load_entry_point
    return ep.load()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2434, in load
    return self.resolve()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2440, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib/python3.7/site-packages/castero/__main__.py", line 79, in <module>
    main()
  File "/usr/lib/python3.7/site-packages/castero/__main__.py", line 69, in main
    display.display()
  File "/usr/lib/python3.7/site-packages/castero/display.py", line 328, in display
    self._perspectives[self._active_perspective].display()
  File "/usr/lib/python3.7/site-packages/castero/perspectives/primaryperspective.py", line 115, in display
    self._feed_menu.display()
  File "/usr/lib/python3.7/site-packages/castero/menu.py", line 182, in display
    self._window.addstr(y, 0, self._pad_text(""))
_curses.error: addwstr() returned ERR
```