### PR TITLE
Add filter for menus

### DIFF
--- a/castero/__init__.py
+++ b/castero/__init__.py
@@ -37,6 +37,7 @@ Commands
     {key_clear} - clear the queue
     {key_next} - go to the next episode in the queue
     {key_invert} - invert the order of the menu
+    {key_filter} - filter the contents of the menu
     {key_mark_played} - mark episode as played/unplayed
     {key_pause_play|key_pause_play_alt} - pause/play the current episode
     {key_seek_forward|key_seek_forward_alt} - seek forward

--- a/castero/display.py
+++ b/castero/display.py
@@ -13,6 +13,7 @@ from castero.downloadqueue import DownloadQueue
 from castero.feed import Feed, FeedError, FeedLoadError, FeedDownloadError, \
     FeedParseError, FeedStructureError
 from castero.episode import Episode
+from castero.menu import Menu
 from castero.perspective import Perspective
 from castero.queue import Queue
 from castero.player import Player
@@ -555,6 +556,10 @@ class Display:
                     episode.delete(self)
             else:
                 self._download_queue.add(episode)
+
+    def filter_menu(self, menu: Menu) -> None:
+        menu.filter_text = self._get_input_str("Filter: ")
+        self.menus_valid = False
 
     def clear(self) -> None:
         """Clear the screen.

--- a/castero/menu.py
+++ b/castero/menu.py
@@ -34,6 +34,7 @@ class Menu(ABC):
         self._display_start_y = 2
         self._top_index = 0
         self._inverted = False
+        self._filter_text = ""
 
         if child is not None:
             self.update_child()
@@ -276,3 +277,12 @@ class Menu(ABC):
     @window.setter
     def window(self, window) -> None:
         self._window = window
+
+    @property
+    def filter_text(self) -> str:
+        """str: the filter applied to the menu"""
+        return self._filter_text
+
+    @filter_text.setter
+    def filter_text(self, filter_text) -> None:
+        self._filter_text = filter_text

--- a/castero/menus/episodemenu.py
+++ b/castero/menus/episodemenu.py
@@ -16,7 +16,7 @@ class EpisodeMenu(Menu):
         self._episodes = []
 
     def __len__(self) -> int:
-        return len(self._episodes)
+        return len(self._filtered_episodes)
 
     @property
     def _items(self):
@@ -25,7 +25,7 @@ class EpisodeMenu(Menu):
         Overrides method from Menu; see documentation in that class.
         """
         result = []
-        for episode in self._episodes:
+        for episode in self._filtered_episodes:
             tags = []
             if episode.downloaded:
                 tags.append('D')
@@ -44,10 +44,10 @@ class EpisodeMenu(Menu):
 
         Overrides method from Menu; see documentation in that class.
         """
-        if len(self._episodes) == 0:
+        if len(self._filtered_episodes) == 0:
             return None
 
-        return self._episodes[self._selected]
+        return self._filtered_episodes[self._selected]
 
     @property
     def metadata(self) -> str:
@@ -55,10 +55,10 @@ class EpisodeMenu(Menu):
 
         Overrides method from Menu; see documentation in that class.
         """
-        if len(self._episodes) == 0:
+        if len(self._filtered_episodes) == 0:
             return ""
 
-        return self._episodes[self._selected].metadata
+        return self._filtered_episodes[self._selected].metadata
 
     def update_items(self, feed: Feed):
         """Called by the parent menu (the feeds menu) to update our items.
@@ -97,3 +97,10 @@ class EpisodeMenu(Menu):
         super().invert()
 
         self.update_items(self._feed)
+
+    @property
+    def _filtered_episodes(self):
+        """A list of episodes which match the menu filter.
+        """
+        return list(filter(
+            lambda ep: self._filter_text in str(ep).lower(), self._episodes))

--- a/castero/menus/feedmenu.py
+++ b/castero/menus/feedmenu.py
@@ -17,7 +17,7 @@ class FeedMenu(Menu):
         super().__init__(window, source, child=child, active=active)
 
     def __len__(self) -> int:
-        return len(self._feeds)
+        return len(self._filtered_feeds)
 
     @property
     def _items(self):
@@ -40,10 +40,10 @@ class FeedMenu(Menu):
 
         Overrides method from Menu; see documentation in that class.
         """
-        if len(self._feeds) == 0:
+        if len(self._filtered_feeds) == 0:
             return None
 
-        return self._feeds[self._selected]
+        return self._filtered_feeds[self._selected]
 
     @property
     def metadata(self) -> str:
@@ -75,10 +75,11 @@ class FeedMenu(Menu):
 
         Overrides method from Menu; see documentation in that class.
         """
-        if len(self._feeds) == 0:
+        if len(self._filtered_feeds) == 0:
             self.update_items(None)
+            self._child.update_items(None)
         else:
-            self._child.update_items(self._feeds[self._selected])
+            self._child.update_items(self._filtered_feeds[self._selected])
 
     def invert(self):
         """Invert the menu order.
@@ -88,3 +89,10 @@ class FeedMenu(Menu):
         super().invert()
 
         self.update_items(None)
+
+    @property
+    def _filtered_feeds(self):
+        """A list of feeds which match the menu filter.
+        """
+        return list(filter(
+            lambda feed: self._filter_text in str(feed).lower(), self._feeds))

--- a/castero/perspective.py
+++ b/castero/perspective.py
@@ -85,6 +85,11 @@ class Perspective(ABC):
         """
 
     @abstractmethod
+    def _invert_selected_menu(self) -> None:
+        """Inverts the contents of the selected menu.
+        """
+
+    @abstractmethod
     def _get_active_menu(self) -> Menu:
         """Retrieve the active Menu, if there is one.
 
@@ -163,6 +168,15 @@ class Perspective(ABC):
                 self._display.save_episodes(episode=self._episode_menu.item)
         elif c == key_mapping[Config['key_invert']]:
             self._invert_selected_menu()
+        elif c == key_mapping[Config['key_filter']]:
+            menu = self._get_active_menu()
+            if menu.filter_text:
+                menu.filter_text = ""
+            else:
+                self._display.filter_menu(menu)
+            self._feed_menu.update_child()
+            menu.move(-1)
+            menu.move(1)
         elif c == key_mapping[Config['key_mark_played']]:
             if self._active_window == 0:
                 feed = self._feed_menu.item

--- a/castero/perspectives/primaryperspective.py
+++ b/castero/perspectives/primaryperspective.py
@@ -177,6 +177,15 @@ class PrimaryPerspective(Perspective):
             1: self._episode_menu,
         }.get(self._active_window)
 
+    def _invert_selected_menu(self) -> None:
+        """Inverts the contents of the selected menu.
+
+        Overrides method from Perspective; see documentation in that class.
+        """
+        self._get_active_menu().invert()
+        if self._feed_menu:
+            self._feed_menu.update_child()
+
     def _create_player_from_selected(self) -> None:
         """Creates player(s) based on the selected items and adds to the queue.
 
@@ -202,10 +211,3 @@ class PrimaryPerspective(Perspective):
                     self._display.AVAILABLE_PLAYERS, str(episode),
                     episode.get_playable(), episode)
                 self._display.queue.add(player)
-
-    def _invert_selected_menu(self) -> None:
-        """Inverts the contents of the selected menu.
-        """
-        self._get_active_menu().invert()
-        if self._feed_menu:
-            self._feed_menu.update_child()

--- a/castero/perspectives/queueperspective.py
+++ b/castero/perspectives/queueperspective.py
@@ -159,6 +159,13 @@ class QueuePerspective(Perspective):
 
         return self._queue_menu
 
+    def _invert_selected_menu(self) -> None:
+        """Inverts the contents of the selected menu.
+
+        Overrides method from Perspective; see documentation in that class.
+        """
+        pass
+
     def _remove_selected_from_queue(self) -> None:
         """Remove the selected player from the queue.
         """

--- a/castero/perspectives/simpleperspective.py
+++ b/castero/perspectives/simpleperspective.py
@@ -156,6 +156,15 @@ class SimplePerspective(Perspective):
             1: self._episode_menu,
         }.get(self._active_window)
 
+    def _invert_selected_menu(self) -> None:
+        """Inverts the contents of the selected menu.
+
+        Overrides method from Perspective; see documentation in that class.
+        """
+        self._get_active_menu().invert()
+        if self._feed_menu:
+            self._feed_menu.update_child()
+
     def _create_player_from_selected(self) -> None:
         """Creates player(s) based on the selected items and adds to the queue.
 
@@ -181,10 +190,3 @@ class SimplePerspective(Perspective):
                     self._display.AVAILABLE_PLAYERS, str(episode),
                     episode.get_playable(), episode)
                 self._display.queue.add(player)
-
-    def _invert_selected_menu(self) -> None:
-        """Inverts the contents of the selected menu.
-        """
-        self._get_active_menu().invert()
-        if self._feed_menu:
-            self._feed_menu.update_child()

--- a/castero/templates/castero.conf
+++ b/castero/templates/castero.conf
@@ -172,6 +172,10 @@ key_next = n
 # default: i
 key_invert = i
 
+# Filter the menu. Press again to clear the filter.
+# default: /
+key_filter = /
+
 # Mark the episode as played/unplayed.
 # default: i
 key_mark_played = m

--- a/castero/templates/castero.conf
+++ b/castero/templates/castero.conf
@@ -172,7 +172,7 @@ key_next = n
 # default: i
 key_invert = i
 
-# Filter the menu. Press again to clear the filter.
+# Filter the contents of the menu. Press again to clear the filter.
 # default: /
 key_filter = /
 


### PR DESCRIPTION
Press `/` (configurable) to open a field to filter the selected menu. Pressing it again clears the filter.

See #45