### PR TITLE
Only include episodes with an enclosure in feed

### DIFF
--- a/castero/feed.py
+++ b/castero/feed.py
@@ -306,6 +306,11 @@ class Feed:
                 if 'url' in item_enclosure.attrib.keys():
                     item_enclosure_str = item_enclosure.attrib['url']
 
+            # if we were unable to find an enclosure for this episode,
+            # don't add it
+            if not item_enclosure_str:
+                continue
+
             episodes.append(
                 Episode(self,
                         title=item_title_str,

--- a/tests/feeds/valid_basic.xml
+++ b/tests/feeds/valid_basic.xml
@@ -7,12 +7,15 @@
         <item>
             <title>myfeed item1 title</title>
             <description>myfeed item1 description</description>
+            <enclosure url="http://example.com/myfeed_item1_title.mp3"/>
         </item>
         <item>
             <title>myfeed item2 title</title>
+            <enclosure url="http://example.com/myfeed_item2_title.mp3"/>
         </item>
         <item>
             <description>myfeed item3 description</description>
+            <enclosure url="http://example.com/myfeed_item3_title.mp3"/>
         </item>
     </channel>
 </rss>

--- a/tests/feeds/valid_mixed_enclosures.xml
+++ b/tests/feeds/valid_mixed_enclosures.xml
@@ -11,7 +11,6 @@
         </item>
         <item>
             <title>myfeed item2 title</title>
-            <enclosure url="http://example.com/myfeed_item2_title.mp3"/>
         </item>
         <item>
             <description>myfeed item3 description</description>

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -118,7 +118,7 @@ def test_display_update(display):
 
 
 def test_display_nonempty(display):
-    myfeed = Feed(file=my_dir + "/feeds/valid_enclosures.xml")
+    myfeed = Feed(file=my_dir + "/feeds/valid_basic.xml")
     display.database.feeds = mock.MagicMock(return_value=[myfeed])
     display.menus_valid = False
     display.display()
@@ -135,7 +135,7 @@ def test_display_min_dimensions(display):
 
 
 def test_display_add_feed(display):
-    feed_dir = my_dir + "/feeds/valid_enclosures.xml"
+    feed_dir = my_dir + "/feeds/valid_basic.xml"
     display._get_input_str = mock.MagicMock(return_value=feed_dir)
     display.add_feed()
     assert len(display.database.feeds()) == 1

--- a/tests/test_downloadqueue.py
+++ b/tests/test_downloadqueue.py
@@ -7,7 +7,7 @@ from castero.feed import Feed
 
 my_dir = os.path.dirname(os.path.realpath(__file__))
 
-feed = Feed(file=my_dir + "/feeds/valid_enclosures.xml")
+feed = Feed(file=my_dir + "/feeds/valid_basic.xml")
 episode1 = Episode(feed=feed, title="episode1 title")
 episode2 = Episode(feed=feed, title="episode2 title")
 

--- a/tests/test_episode.py
+++ b/tests/test_episode.py
@@ -106,7 +106,7 @@ def test_episode_missing_property_enclosure():
 
 
 def test_episode_playable_remote():
-    myfeed = Feed(file=my_dir + "/feeds/valid_enclosures.xml")
+    myfeed = Feed(file=my_dir + "/feeds/valid_basic.xml")
     episode = myfeed.parse_episodes()[0]
     playable = episode.get_playable()
     assert not episode.downloaded
@@ -115,7 +115,7 @@ def test_episode_playable_remote():
 
 def test_episode_playable_local():
     DataFile.DEFAULT_DOWNLOADED_DIR = os.path.join(my_dir, "downloaded")
-    myfeed = Feed(file=my_dir + "/feeds/valid_enclosures.xml")
+    myfeed = Feed(file=my_dir + "/feeds/valid_basic.xml")
     episode = myfeed.parse_episodes()[0]
     playable = episode.get_playable()
     assert episode.downloaded
@@ -133,7 +133,7 @@ def test_episode_delete(display):
                                     "myfeed_title/myfeed_item2_title.mp3")
     with open(episode_location, "w") as file:
         file.write("temp file for test_episode.test_episode_delete")
-    myfeed = Feed(file=my_dir + "/feeds/valid_enclosures.xml")
+    myfeed = Feed(file=my_dir + "/feeds/valid_basic.xml")
     display.change_status = mock.MagicMock(name="change_status")
     episode = myfeed.parse_episodes()[1]
     assert episode.downloaded
@@ -148,7 +148,7 @@ def test_episode_delete(display):
 def test_episode_download():
     DataFile.DEFAULT_DOWNLOADED_DIR = os.path.join(my_dir, "downloaded")
     mydownloadqueue = DownloadQueue()
-    myfeed = Feed(file=my_dir + "/feeds/valid_enclosures.xml")
+    myfeed = Feed(file=my_dir + "/feeds/valid_basic.xml")
     myepisode = myfeed.parse_episodes()[1]
     DataFile.download_to_file = mock.MagicMock(name="download_to_file")
     myepisode.download(mydownloadqueue)
@@ -161,7 +161,7 @@ def test_episode_download():
 def test_episode_download_with_display(display):
     DataFile.DEFAULT_DOWNLOADED_DIR = os.path.join(my_dir, "downloaded")
     mydownloadqueue = DownloadQueue()
-    myfeed = Feed(file=my_dir + "/feeds/valid_enclosures.xml")
+    myfeed = Feed(file=my_dir + "/feeds/valid_basic.xml")
     myepisode = myfeed.parse_episodes()[1]
     DataFile.download_to_file = mock.MagicMock(name="download_to_file")
     display.change_status = mock.MagicMock(name="change_status")

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -11,12 +11,21 @@ def test_feed_validation_valid():
     myfeed = feed.Feed(file=my_dir + "/feeds/valid_basic.xml")
     assert isinstance(myfeed, feed.Feed)
     assert myfeed.validated
+    assert len(myfeed.parse_episodes()) == 3
 
 
 def test_feed_validation_complete():
-    myfeed = feed.Feed(file=my_dir + "/feeds/valid_basic.xml")
+    myfeed = feed.Feed(file=my_dir + "/feeds/valid_complete.xml")
     assert isinstance(myfeed, feed.Feed)
     assert myfeed.validated
+    assert len(myfeed.parse_episodes()) == 3
+
+
+def test_feed_validation_valid_mixed_enclosure():
+    myfeed = feed.Feed(file=my_dir + "/feeds/valid_mixed_enclosures.xml")
+    assert isinstance(myfeed, feed.Feed)
+    assert myfeed.validated
+    assert len(myfeed.parse_episodes()) == 2
 
 
 def test_feed_validations_is_rss():

--- a/tests/test_perspective_primary.py
+++ b/tests/test_perspective_primary.py
@@ -188,7 +188,7 @@ def test_perspective_regression_11(display):
     old_ddir = Config["custom_download_dir"]
     Config.data["custom_download_dir"] = os.path.join(my_dir, "downloaded")
 
-    feed = Feed(file="%s/feeds/valid_enclosures.xml" % (my_dir))
+    feed = Feed(file="%s/feeds/valid_basic.xml" % (my_dir))
     display.database.replace_feed(feed)
     display.database.replace_episodes(feed, feed.parse_episodes())
     display.menus_valid = False

--- a/tests/test_perspective_simple.py
+++ b/tests/test_perspective_simple.py
@@ -138,7 +138,7 @@ def test_perspective_regression_11(display):
     old_ddir = Config["custom_download_dir"]
     Config.data["custom_download_dir"] = os.path.join(my_dir, "downloaded")
 
-    feed = Feed(file="%s/feeds/valid_enclosures.xml" % (my_dir))
+    feed = Feed(file="%s/feeds/valid_basic.xml" % (my_dir))
     display.database.replace_feed(feed)
     display.database.replace_episodes(feed, feed.parse_episodes())
     display.menus_valid = False


### PR DESCRIPTION
In a feed's parse_episodes, we now skip episodes without an `enclosure` tag.

We may still need to look into crashing/UI issues when an enclosure is simply a bad URL (particularly when trying to download).