### PR TITLE
add additional foreground color options

### DIFF
--- a/castero/display.py
+++ b/castero/display.py
@@ -146,6 +146,21 @@ class Display:
             self.color_number(Config["color_foreground_dim"]),
             self.color_number(Config["color_background"]),
         )
+        curses.init_pair(
+            6,
+            self.color_number(Config["color_foreground_status"]),
+            self.color_number(Config["color_background"]),
+        )
+        curses.init_pair(
+            7,
+            self.color_number(Config["color_foreground_heading"]),
+            self.color_number(Config["color_background"]),
+        )
+        curses.init_pair(
+            8,
+            self.color_number(Config["color_foreground_dividers"]),
+            self.color_number(Config["color_background"]),
+        )
 
     def _load_perspectives(self) -> None:
         """Load instances of perspectives from the `perspectives` package.
@@ -233,7 +248,6 @@ class Display:
         padding_yx = (1, 4)
 
         help_window = curses.newwin(self._parent_y, self._parent_x, 0, 0)
-        help_window.attron(curses.A_BOLD)
 
         # display lines from __help__
         help_lines = \
@@ -241,7 +255,8 @@ class Display:
         help_lines.append("Press any key to exit this screen.")
         for i in range(len(help_lines)):
             help_window.addstr(i + padding_yx[0], padding_yx[1],
-                               help_lines[i][:self._parent_x - padding_yx[1]])
+                               help_lines[i][:self._parent_x - padding_yx[1]],
+                               curses.A_BOLD)
         help_window.refresh()
 
         # simply wait until any key is pressed (temporarily disable timeout)
@@ -263,10 +278,6 @@ class Display:
                 self._perspectives[perspective_id].update_menus()
             self.menus_valid = True
 
-        # update window colors
-        self._header_window.bkgd(curses.color_pair(4))
-        self._footer_window.bkgd(curses.color_pair(4))
-
         # add header
         playing_str = castero.__title__
         if self._queue.first is not None:
@@ -282,10 +293,10 @@ class Display:
             else:
                 playing_str += " [%s]" % self._queue.first.time_str
 
-        self._header_window.attron(curses.A_BOLD)
         self._header_window.addstr(0, 0,
                                    " " * self._header_window.getmaxyx()[1])
-        self._header_window.addstr(0, 0, playing_str)
+        self._header_window.addstr(0, 0, playing_str,
+                                   curses.color_pair(6) | curses.A_BOLD)
 
         # add footer
         footer_str = ""
@@ -314,15 +325,19 @@ class Display:
         if footer_str != "":
             footer_str += " -- Press %s for help" % Config["key_help"]
 
-        self._footer_window.attron(curses.A_BOLD)
         footer_str = footer_str[:self._footer_window.getmaxyx()[1] - 1]
-        self._footer_window.addstr(1, 0, footer_str)
+        self._footer_window.addstr(0, 0,
+                                   " " * self._footer_window.getmaxyx()[1])
+        self._footer_window.addstr(1, 0, footer_str,
+                                   curses.color_pair(6) | curses.A_BOLD)
 
         # add window borders
         self._header_window.hline(1, 0,
-                                  0, self._header_window.getmaxyx()[1])
+                                  0, self._header_window.getmaxyx()[1],
+                                  curses.ACS_HLINE | curses.color_pair(8))
         self._footer_window.hline(0, 0,
-                                  0, self._footer_window.getmaxyx()[1])
+                                  0, self._footer_window.getmaxyx()[1],
+                                  curses.ACS_HLINE | curses.color_pair(8))
 
         # update display for current perspective
         self._perspectives[self._active_perspective].display()

--- a/castero/perspective.py
+++ b/castero/perspective.py
@@ -247,11 +247,10 @@ class Perspective(ABC):
 
         y = 2
         for line in lines[:max_lines]:
+            attr = curses.color_pair(1)
             if line.startswith('!cb'):
-                window.attron(curses.A_BOLD)
+                attr |= curses.A_BOLD
                 line = line[3:]
-            else:
-                window.attrset(curses.color_pair(1))
 
-            window.addstr(y, 0, line)
+            window.addstr(y, 0, line, attr)
             y += 1

--- a/castero/perspectives/primaryperspective.py
+++ b/castero/perspectives/primaryperspective.py
@@ -82,34 +82,33 @@ class PrimaryPerspective(Perspective):
 
         Overrides method from Perspective; see documentation in that class.
         """
-        # update window colors
-        self._feed_window.bkgd(curses.color_pair(1))
-        self._episode_window.bkgd(curses.color_pair(1))
-        self._metadata_window.bkgd(curses.color_pair(1))
-
-        # add window titles
-        self._feed_window.attron(curses.A_BOLD)
-        self._episode_window.attron(curses.A_BOLD)
-        self._metadata_window.attron(curses.A_BOLD)
-        self._feed_window.addstr(0, 0, "Feeds")
-        self._episode_window.addstr(0, 0, "Episodes")
-        self._metadata_window.addstr(0, 0, "Metadata")
+        # add window headers
+        self._feed_window.addstr(0, 0, "Feeds",
+                                 curses.color_pair(7) | curses.A_BOLD)
+        self._episode_window.addstr(0, 0, "Episodes",
+                                    curses.color_pair(7) | curses.A_BOLD)
+        self._metadata_window.addstr(0, 0, "Metadata",
+                                     curses.color_pair(7) | curses.A_BOLD)
 
         # add window borders
         self._feed_window.hline(1, 0,
-                                0, self._feed_window.getmaxyx()[1])
-
+                                0, self._feed_window.getmaxyx()[1],
+                                curses.ACS_HLINE | curses.color_pair(8))
         self._episode_window.hline(1, 0,
-                                   0, self._episode_window.getmaxyx()[1])
+                                   0, self._episode_window.getmaxyx()[1],
+                                   curses.ACS_HLINE | curses.color_pair(8))
         self._metadata_window.hline(1, 0,
-                                    0, self._metadata_window.getmaxyx()[1] - 1)
+                                    0, self._metadata_window.getmaxyx()[1] - 1,
+                                    curses.ACS_HLINE | curses.color_pair(8))
         if not helpers.is_true(Config["disable_vertical_borders"]):
             self._feed_window.vline(0, self._feed_window.getmaxyx()[1] - 1,
-                                    0, self._feed_window.getmaxyx()[0] - 2)
+                                    0, self._feed_window.getmaxyx()[0] - 2,
+                                    curses.ACS_VLINE | curses.color_pair(8))
             self._episode_window.vline(0,
                                        self._episode_window.getmaxyx()[1] - 1,
                                        0,
-                                       self._episode_window.getmaxyx()[0] - 2)
+                                       self._episode_window.getmaxyx()[0] - 2,
+                                       curses.ACS_VLINE | curses.color_pair(8))
 
         # display menu content
         self._feed_menu.display()

--- a/castero/perspectives/queueperspective.py
+++ b/castero/perspectives/queueperspective.py
@@ -68,24 +68,23 @@ class QueuePerspective(Perspective):
 
         Overrides method from Perspective; see documentation in that class.
         """
-        # update window colors
-        self._queue_window.bkgd(curses.color_pair(1))
-        self._metadata_window.bkgd(curses.color_pair(1))
-
-        # add window titles
-        self._queue_window.attron(curses.A_BOLD)
-        self._metadata_window.attron(curses.A_BOLD)
-        self._queue_window.addstr(0, 0, "Queue")
-        self._metadata_window.addstr(0, 0, "Metadata")
+        # add window headers
+        self._queue_window.addstr(0, 0, "Queue",
+                                  curses.color_pair(7) | curses.A_BOLD)
+        self._metadata_window.addstr(0, 0, "Metadata",
+                                     curses.color_pair(7) | curses.A_BOLD)
 
         # add window borders
         self._queue_window.hline(1, 0,
-                                 0, self._queue_window.getmaxyx()[1])
+                                 0, self._queue_window.getmaxyx()[1],
+                                 curses.ACS_HLINE | curses.color_pair(8))
         self._metadata_window.hline(1, 0,
-                                    0, self._metadata_window.getmaxyx()[1] - 1)
+                                    0, self._metadata_window.getmaxyx()[1] - 1,
+                                    curses.ACS_HLINE | curses.color_pair(8))
         if not helpers.is_true(Config["disable_vertical_borders"]):
             self._queue_window.vline(0, self._queue_window.getmaxyx()[1] - 1,
-                                     0, self._queue_window.getmaxyx()[0] - 2)
+                                     0, self._queue_window.getmaxyx()[0] - 2,
+                                     curses.ACS_VLINE | curses.color_pair(8))
 
         # display menu content
         self._queue_menu.display()

--- a/castero/perspectives/simpleperspective.py
+++ b/castero/perspectives/simpleperspective.py
@@ -76,24 +76,23 @@ class SimplePerspective(Perspective):
 
         Overrides method from Perspective; see documentation in that class.
         """
-        # update window colors
-        self._feed_window.bkgd(curses.color_pair(1))
-        self._episode_window.bkgd(curses.color_pair(1))
-
-        # add window titles
-        self._feed_window.attron(curses.A_BOLD)
-        self._episode_window.attron(curses.A_BOLD)
-        self._feed_window.addstr(0, 0, "Feeds")
-        self._episode_window.addstr(0, 0, "Episodes")
+        # add window headers
+        self._feed_window.addstr(0, 0, "Feeds",
+                                 curses.color_pair(7) | curses.A_BOLD)
+        self._episode_window.addstr(0, 0, "Episodes",
+                                    curses.color_pair(7) | curses.A_BOLD)
 
         # add window borders
         self._feed_window.hline(1, 0,
-                                0, self._feed_window.getmaxyx()[1])
+                                0, self._feed_window.getmaxyx()[1],
+                                curses.ACS_HLINE | curses.color_pair(8))
         self._episode_window.hline(1, 0,
-                                   0, self._episode_window.getmaxyx()[1])
+                                   0, self._episode_window.getmaxyx()[1],
+                                   curses.ACS_HLINE | curses.color_pair(8))
         if not helpers.is_true(Config["disable_vertical_borders"]):
             self._feed_window.vline(0, self._feed_window.getmaxyx()[1] - 1,
-                                    0, self._feed_window.getmaxyx()[0] - 2)
+                                    0, self._feed_window.getmaxyx()[0] - 2,
+                                    curses.ACS_VLINE | curses.color_pair(8))
 
         # display menu content
         self._feed_menu.display()

--- a/castero/templates/castero.conf
+++ b/castero/templates/castero.conf
@@ -87,6 +87,17 @@ color_background_alt = black
 # default: green
 color_foreground_dim = green
 
+# The foreground (text) color of status lines. Paired with color_background.
+# default: white
+color_foreground_status = white
+
+# The foreground (text) color of menu headings. Paired with color_background.
+# default: yellow
+color_foreground_heading = yellow
+
+# The foreground (text) color of dividers. Paired with color_background.
+# default: white
+color_foreground_dividers = white
 
 [playback]
 # The distance to move forward when pressing seek keys, in seconds.

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -18,16 +18,16 @@ def test_display_init(display):
 
 def test_display_display_header(display):
     display.display()
-    display._header_window.attron.assert_called_with(curses.A_BOLD)
-    display._header_window.addstr.assert_called_with(0, 0, castero.__title__)
+    display._header_window.addstr.assert_called_with(
+        0, 0, castero.__title__, curses.color_pair(6) | curses.A_BOLD)
     display._stdscr.reset_mock()
 
 
 def test_display_display_footer_empty(display):
     display.display()
-    display._footer_window.attron.assert_called_with(curses.A_BOLD)
     display._footer_window.addstr.assert_called_with(
-        1, 0, "No feeds added -- Press h for help"
+        1, 0, "No feeds added -- Press h for help",
+        curses.color_pair(6) | curses.A_BOLD
     )
     display._stdscr.reset_mock()
     feed = Feed(url="feed url",
@@ -38,11 +38,11 @@ def test_display_display_footer_empty(display):
                 copyright="feed copyright")
     display.database.feeds = mock.MagicMock(return_value=[feed])
     display.display()
-    display._footer_window.attron.assert_called_with(curses.A_BOLD)
     display._footer_window.addstr.assert_called_with(
         1, 0,
         "Found 1 feeds with 0 total episodes (avg. 0 episodes, med. 0)"
-        " -- Press h for help"
+        " -- Press h for help",
+        curses.color_pair(6) | curses.A_BOLD
     )
 
 


### PR DESCRIPTION
Adds the following color config options:
```
color_foreground_status (for the header and footer bars)
color_foreground_heading (for menu headings, i.e. Feeds, Episodes, Metadata)
color_foreground_dividers
```