### PR TITLE
remove apparent_encoding detection from net request

### DIFF
--- a/castero/net.py
+++ b/castero/net.py
@@ -25,6 +25,4 @@ class Net:
         Returns:
             requests.models.Response: response
         """
-        r = requests.get(url, headers=Net.HEADERS, **kwargs)
-        r.encoding = r.apparent_encoding
-        return r
+        return requests.get(url, headers=Net.HEADERS, **kwargs)


### PR DESCRIPTION
Reverts #49. The `apparent_encoding` field would, at least in some cases, never resolve while eating up massive CPU. This caused the download threads to hang.