### PR TITLE
Improved error messages for problematic .opml files

### DIFF
--- a/castero/feed.py
+++ b/castero/feed.py
@@ -216,12 +216,16 @@ class Feed:
                             raise FeedStructureError(
                                 "RSS feed's channel has too many or too few"
                                 " link tags; expected 1, was: "
-                                + str(len(chan_link_tags)))
+                                + str(len(chan_link_tags))
+                                + ". The corresponding title is: "
+                                + str(chan_title_tags[0].text))
                         if len(chan_description_tags) != 1:
                             raise FeedStructureError(
                                 "RSS feed's channel has too many or too few"
                                 " description tags; expected 1, was: "
-                                + str(len(chan_description_tags)))
+                                + str(len(chan_description_tags))
+                                + ". The corresponding title is: "
+                                + str(chan_title_tags[0].text))
 
                         # if the channel has any items, each item should have
                         # at least a title or description tag


### PR DESCRIPTION
I had some problems importing a buggy .opml file.
I got an error about a buggy Channel but it didn't specify which one.
It was quite hard to find out which one since there were a lot.
Turned out it was a missing URL. 
Since if there is no title the file is empty that fine. 
For URL and XML errors, I now return the corresponding title in the error message. 
Not sure that warrants a change in the change log, let me know if you need anything else to accept the change. 