### PR TITLE
retain episode ids when feeds are reloaded

### DIFF
--- a/castero/episode.py
+++ b/castero/episode.py
@@ -171,11 +171,12 @@ class Episode:
         return self._downloaded
 
     def replace_from(self, episode) -> None:
-        """Replace user-specific metadata from the given episode.
+        """Replace metadata from the given episode.
 
         Args:
             episode: the source Episode
         """
+        self._ep_id = episode._ep_id
         self._played = episode._played
 
     @property


### PR DESCRIPTION
Fixes an issue where downloaded episodes wouldn't be recognized after reloading, since the episode filename is prefixed with the ep_id, and we were creating new ids on each reload.