### PR TITLE
Play rate resetting to default.

### DIFF
--- a/castero/player.py
+++ b/castero/player.py
@@ -148,15 +148,6 @@ class Player:
         """
 
     @abstractmethod
-    def change_rate(self, direction, display=None) -> None:
-        """Increase or decrease the playback speed.
-
-        Args:
-            direction: 1 to increase, -1 to decrease
-            display: (optional) the display to write status updates to
-        """
-
-    @abstractmethod
     def set_rate(self, rate) -> None:
         """Set the playback speed.
 

--- a/castero/players/mpvplayer.py
+++ b/castero/players/mpvplayer.py
@@ -83,19 +83,6 @@ class MPVPlayer(Player):
         if self._player is not None:
             self._player.seek(direction * amount)
 
-    def change_rate(self, direction, display=None) -> None:
-        """Increase or decrease the playback speed.
-
-        Overrides method from Player; see documentation in that class.
-        """
-        assert direction == 1 or direction == -1
-        if self._player is not None:
-            new_rate = self._player.speed + 0.1 * direction
-            self._player.speed = new_rate
-            if display:
-                display.change_status(
-                    "Playback speed set to {:0.2f}".format(new_rate))
-
     def set_rate(self, rate) -> None:
         """Set the playback speed.
 

--- a/castero/players/vlcplayer.py
+++ b/castero/players/vlcplayer.py
@@ -91,19 +91,6 @@ class VLCPlayer(Player):
                 self._player.get_time() + (direction * amount * 1000)
             )
 
-    def change_rate(self, direction, display=None) -> None:
-        """Increase or decrease the playback speed.
-
-        Overrides method from Player; see documentation in that class.
-        """
-        assert direction == 1 or direction == -1
-        if self._player is not None:
-            new_rate = self._player.get_rate() + 0.1 * direction
-            self._player.set_rate(new_rate)
-            if display:
-                display.change_status(
-                    "Playback speed set to {:0.2f}".format(new_rate))
-
     def set_rate(self, rate) -> None:
         """Set the playback speed.
 

--- a/castero/queue.py
+++ b/castero/queue.py
@@ -13,7 +13,9 @@ class Queue:
         self._players = []
         self._display = display
         self._volume = int(Config["default_volume"])
+        self._speed = float(Config["default_playback_speed"])
         self._sanitize_volume()
+        self._sanitize_speed()
 
     def __getitem__(self, index):
         return self._players[index]
@@ -24,7 +26,7 @@ class Queue:
     def clear(self) -> None:
         """Clears the queue.
 
-        Tt is extremely likely that the caller of this method will also want to
+        It is extremely likely that the caller of this method will also want to
         stop the first player prior to calling this method.
         """
         for p in self._players:
@@ -67,7 +69,7 @@ class Queue:
             self._display.modified_episodes.append(self.first.episode)
             self.first.play()
             self.first.set_volume(self.volume)
-            self.first.set_rate(float(Config["default_playback_speed"]))
+            self.first.set_rate(self.speed)
 
     def pause(self) -> None:
         """Pauses the first player in the queue.
@@ -114,9 +116,18 @@ class Queue:
             display: (optional) the display to write status updates to
         """
         assert direction == 1 or direction == -1
+        
+        # First we change our speed value, then we set the player speed
+        # to that amount. This ensures the player speed is always derived
+        # from our value.
+        self._speed += 0.1 * direction
+        self._sanitize_speed()
 
         if self.first is not None:
-            self.first.change_rate(direction, display=display)
+            self.first.set_rate(self.speed)
+            #Update the display status
+            self._display.change_status (
+                "Playback speed set to {:0.2f}".format(self.speed))
 
     def change_volume(self, direction) -> None:
         """Increase or decrease volume of the current player.
@@ -169,6 +180,14 @@ class Queue:
         elif self._volume < 0:
             self._volume = 0
 
+    def _sanitize_speed(self) -> None:
+        """Ensure the speed is an acceptable value (0.5-2.0 inclusive)
+        """
+        if (self._speed < 0.5):
+            self._speed = 0.5
+        elif self._speed > 2.0:
+            self._speed =  2.0
+
     @property
     def first(self) -> Player:
         """Player: the first player in the queue"""
@@ -186,3 +205,8 @@ class Queue:
     def volume(self) -> int:
         """int: the current playback volume"""
         return self._volume
+
+    @property
+    def speed(self) -> float:
+        """float: the current playback speed"""
+        return self._speed

--- a/castero/queue.py
+++ b/castero/queue.py
@@ -8,6 +8,10 @@ class Queue:
     This class is also the display class' main interface for accessing
     information about the current player.
     """
+    MIN_VOLUME = 0
+    MAX_VOLUME = 100
+    MIN_SPEED = 0.5
+    MAX_SPEED = 2.0
 
     def __init__(self, display) -> None:
         self._players = []
@@ -175,18 +179,18 @@ class Queue:
     def _sanitize_volume(self) -> None:
         """Ensure the volume is an acceptable value (0-100 inclusive).
         """
-        if self._volume > 100:
-            self._volume = 100
-        elif self._volume < 0:
-            self._volume = 0
+        if self._volume > self.MAX_VOLUME:
+            self._volume = self.MAX_VOLUME
+        elif self._volume < self.MIN_VOLUME:
+            self._volume = self.MIN_VOLUME
 
     def _sanitize_speed(self) -> None:
         """Ensure the speed is an acceptable value (0.5-2.0 inclusive)
         """
-        if (self._speed < 0.5):
-            self._speed = 0.5
-        elif self._speed > 2.0:
-            self._speed =  2.0
+        if (self._speed < self.MIN_SPEED):
+            self._speed = self.MIN_SPEED
+        elif self._speed > self.MAX_SPEED:
+            self._speed = self.MAX_SPEED
 
     @property
     def first(self) -> Player:

--- a/tests/test_player_mpvplayer.py
+++ b/tests/test_player_mpvplayer.py
@@ -65,32 +65,12 @@ def test_player_mpv_seek():
     myplayer._player.seek.assert_called_with(10)
 
 
-def test_player_mpv_change_rate_increase():
+def test_player_mpv_set_rate():
     myplayer = MPVPlayer("player1 title", "player1 path", episode)
     myplayer._player = mock.MagicMock()
 
-    myplayer._player.speed = 1
-    myplayer.change_rate(1)
-    assert myplayer._player.speed == 1.1
-
-
-def test_player_mpv_change_rate_decrease():
-    myplayer = MPVPlayer("player1 title", "player1 path", episode)
-    myplayer._player = mock.MagicMock()
-
-    myplayer._player.speed = 1
-    myplayer.change_rate(-1)
-    assert myplayer._player.speed == 0.9
-
-
-def test_player_mpv_change_rate_display():
-    myplayer = MPVPlayer("player1 title", "player1 path", episode)
-    myplayer._player = mock.MagicMock()
-    display = mock.MagicMock()
-
-    myplayer._player.speed = 1
-    myplayer.change_rate(1, display=display)
-    assert display.change_status.call_count == 1
+    myplayer.set_rate(1.6)
+    assert myplayer._player.speed == 1.6
 
 
 def test_player_mpv_str():

--- a/tests/test_player_vlcplayer.py
+++ b/tests/test_player_vlcplayer.py
@@ -69,33 +69,12 @@ def test_player_vlc_seek():
         myplayer._player.get_time() + 10 * 1000)
 
 
-def test_player_vlc_change_rate_increase():
+def test_player_vlc_set_rate():
     myplayer = VLCPlayer("player1 title", "player1 path", episode)
     myplayer._player = mock.MagicMock()
-    myplayer._player.get_rate = mock.MagicMock(return_value=1)
 
-    myplayer.change_rate(1)
-    myplayer._player.set_rate.assert_called_with(1.1)
-
-
-def test_player_vlc_change_rate_decrease():
-    myplayer = VLCPlayer("player1 title", "player1 path", episode)
-    myplayer._player = mock.MagicMock()
-    myplayer._player.get_rate = mock.MagicMock(return_value=1)
-
-    myplayer.change_rate(-1)
-    myplayer._player.set_rate.assert_called_with(0.9)
-
-
-def test_player_vlc_change_rate_display():
-    myplayer = VLCPlayer("player1 title", "player1 path", episode)
-    myplayer._player = mock.MagicMock()
-    myplayer._player.get_rate = mock.MagicMock(return_value=1)
-    display = mock.MagicMock()
-
-    myplayer.change_rate(1, display=display)
-    assert display.change_status.call_count == 1
-
+    myplayer.set_rate(1.6)
+    assert myplayer._player.set_rate.call_count == 1
 
 def test_player_vlc_str():
     myplayer = VLCPlayer("player1 title", "player1 path", episode)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -174,7 +174,7 @@ def test_queue_change_rate(display):
 
     myqueue.add(player1)
     myqueue.change_rate(-1, display)
-    player1.change_rate.assert_called_with(-1, display=display)
+    assert player1.set_rate.call_count == 1
 
 
 def test_queue_change_volume(display):


### PR DESCRIPTION
I hope I've done this correctly. I've never actually used github or git before. I have hopefully done the research to do things correctly. It's all new to me so I hope I haven't stepped on any toes, screwed anything up, or violated any github etiquette. I found castero a few weeks ago and I love it. I use it every day but there has been one behavior that has annoyed me a little bit and I figured I'd try to fix it rather than submitting an issue for someone else to work on.

If the user changes the playback speed while listening it gets reset to the configured default when a new play command gets executed. I normally listen to podcasts at 1.5x but I have a particular podcast that often includes music and I like to listen to that one at 1x. So when I hit one of those episodes in my queue I manually change the rate to 1x and everything is fine up and until I have to pause castero for a phone call or something. When you resume after a pause, castero resets the playback speed back to the configured default (1.5x in my case) and, if I happen to be listening to that particular podcast, I have to lower it back down to 1x. (This also happens should you transition to the next item in the queue.)

The purpose of this change is to preserve any ad-hoc speed changes that the user has made so they will persevere through these play commands. The default play rate is unchanged and will still be the default when castero next starts. It is just an in-memory continuation of any changes that the user has made to the playback speed.

This change caused the test_queue_change_rate test to fail with a change_rate not called error so I changed it to behave in a similar manner to test_queue_change_volume. Not sure if what I did there is kosher. And I'm also not sure if you'll like the way I update the display in queue.py.change_rate. The underlying call went from change_rate to set_rate and set_rate didn't have a display param so I manually forced the status update in queue.py. I was trying to change as few files as possible but can certainly add a param to the player class and its child classes if you'd prefer the display update to happen at that level.

The validation also required me to add limits to the speed settings (in queue._sanitize_speed) and the limits I chose were completely arbitrary (0.5x - 2.0x.) I chose those because things started sounding really choppy on my system if you went much farther in either direction. If those limits are an issue it is no big deal to change them.

Again, hope I have done everything properly here both with github and the project in general. I've only ever dabbled in Python. (I'm a C# and Delphi guy primarily.) If I haven't let me know and I'll fix it. Or ignore me and I'll go away. Either way I'm really digging this project; keep up the good work!

--Sam