### PR TITLE
Bugfix: Cascade delete working for episodes

### DIFF
--- a/castero/database.py
+++ b/castero/database.py
@@ -302,11 +302,13 @@ class Database():
 
         i = 1
         for player in queue:
-            cursor.execute(self.SQL_QUEUE_REPLACE, (
-                i,
-                player.episode.ep_id
-            ))
-            i += 1
+            episode = player.episode
+            if self.episode(episode.ep_id) is not None:
+                cursor.execute(self.SQL_QUEUE_REPLACE, (
+                    i,
+                    player.episode.ep_id
+                ))
+                i += 1
         self._conn.commit()
 
     def feeds(self) -> List[Feed]:

--- a/castero/database.py
+++ b/castero/database.py
@@ -56,7 +56,6 @@ class Database():
             Config["restrict_memory_usage"])
 
         file_conn = sqlite3.connect(self.PATH, check_same_thread=False)
-        file_conn.execute("PRAGMA foreign_keys = ON")
 
         if self._using_memory:
             memory_conn = sqlite3.connect(":memory:", check_same_thread=False)
@@ -68,6 +67,7 @@ class Database():
         if not existed and os.path.exists(self.OLD_PATH):
             self._create_from_old_feeds()
 
+        self._conn.execute("PRAGMA foreign_keys = ON")
         self.migrate()
 
     def close(self):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -31,6 +31,28 @@ def test_database_feed(prevent_modification):
     assert feed.title == "feed title"
 
 
+def test_database_delete_feed(prevent_modification):
+    copyfile(my_dir + "/datafiles/database_example1.db", Database.PATH)
+    mydatabase = Database()
+    assert len(mydatabase.feeds()) == 2
+
+    feed = mydatabase.feeds()[0]
+    mydatabase.delete_feed(feed)
+    assert len(mydatabase.feeds()) == 1
+
+
+def test_database_delete_feed_and_episode(prevent_modification):
+    copyfile(my_dir + "/datafiles/database_example1.db", Database.PATH)
+    mydatabase = Database()
+
+    feed = mydatabase.feeds()[0]
+    feed_episode = mydatabase.episodes(feed)[0]
+
+    mydatabase.delete_feed(feed)
+    feed_episode = mydatabase.episodes(feed)
+    assert len(feed_episode) == 0
+
+
 def test_database_feed_episodes(prevent_modification):
     copyfile(my_dir + "/datafiles/database_example1.db", Database.PATH)
     mydatabase = Database()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5,6 +5,8 @@ from unittest import mock
 from castero.episode import Episode
 from castero.feed import Feed
 from castero.database import Database
+from castero.queue import Queue
+from castero.player import Player
 
 my_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -184,6 +186,55 @@ def test_database_reload(prevent_modification, display):
     assert display.change_status.call_count == 2
     assert mydatabase.feeds()[0].title == real_title
 
+
+def test_database_replace_queue(display):
+    copyfile(my_dir + "/datafiles/database_example1.db", Database.PATH)
+    mydatabase = Database()
+
+    assert len(mydatabase.queue()) == 0
+
+    myqueue = Queue(display)
+    player1 = mock.MagicMock(spec=Player)
+    feed = mydatabase.feeds()[0]
+    episode = mydatabase.episodes(feed)[0]
+    player1.episode = episode
+    myqueue.add(player1)
+
+    mydatabase.replace_queue(myqueue)
+    assert len(mydatabase.queue()) == 1
+
+
+def test_database_delete_queue(display):
+    copyfile(my_dir + "/datafiles/database_example1.db", Database.PATH)
+    mydatabase = Database()
+
+    myqueue = Queue(display)
+    player1 = mock.MagicMock(spec=Player)
+    feed = mydatabase.feeds()[0]
+    episode = mydatabase.episodes(feed)[0]
+    player1.episode = episode
+    myqueue.add(player1)
+
+    mydatabase.replace_queue(myqueue)
+    assert len(mydatabase.queue()) == 1
+    mydatabase.delete_queue()
+    assert len(mydatabase.queue()) == 0
+
+
+def test_database_replace_queue_with_deleted_episode(display):
+    copyfile(my_dir + "/datafiles/database_example1.db", Database.PATH)
+    mydatabase = Database()
+
+    myqueue = Queue(display)
+    player1 = mock.MagicMock(spec=Player)
+    feed = mydatabase.feeds()[0]
+    episode = mydatabase.episodes(feed)[0]
+    player1.episode = episode
+    myqueue.add(player1)
+
+    mydatabase.delete_feed(feed)
+    mydatabase.replace_queue(myqueue)
+    assert len(mydatabase.queue()) == 0
 
 def test_database_from_json(prevent_modification):
     copyfile(my_dir + "/datafiles/feeds_working", Database.OLD_PATH)


### PR DESCRIPTION
This PR should fix #155.

**Summary of changes:**
* Moved `PRAGMA foreign_keys = ON`
* Added tests for deleting feeds and that episode are removed as well
* Added tests for database interaction towards queue